### PR TITLE
Enable sharing and heart toggle

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,8 +17,21 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class PantallaBienvenida extends StatelessWidget {
+class PantallaBienvenida extends StatefulWidget {
   const PantallaBienvenida({super.key});
+
+  @override
+  State<PantallaBienvenida> createState() => _PantallaBienvenidaState();
+}
+
+class _PantallaBienvenidaState extends State<PantallaBienvenida> {
+  bool _isFavorite = false;
+
+  void _shareQuote() {
+    Share.share(
+      '"Bueno es el Señor con quienes esperan en él, con todos los que lo buscan."\nLAMENTACIONES 3:25',
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -63,10 +77,17 @@ class PantallaBienvenida extends StatelessWidget {
                 const SizedBox(height: 16),
 
                 // Icono de corazón
-                const Icon(
-                  Icons.favorite_border,
-                  color: Colors.white,
-                  size: 30,
+                IconButton(
+                  icon: Icon(
+                    _isFavorite ? Icons.favorite : Icons.favorite_border,
+                    color: _isFavorite ? Colors.red : Colors.white,
+                  ),
+                  iconSize: 30,
+                  onPressed: () {
+                    setState(() {
+                      _isFavorite = !_isFavorite;
+                    });
+                  },
                 ),
 
                 const Spacer(),
@@ -77,9 +98,9 @@ class PantallaBienvenida extends StatelessWidget {
                   child: SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                      onPressed: () {},
+                      onPressed: _shareQuote,
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.black,
+                        backgroundColor: Colors.yellow,
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(30),
@@ -87,7 +108,10 @@ class PantallaBienvenida extends StatelessWidget {
                       ),
                       child: const Text(
                         'COMPARTE LA CITA',
-                        style: TextStyle(color: Colors.white),
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
                   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  share_plus: ^7.2.1
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- add **share_plus** package
- make the welcome screen stateful to support interactions
- allow sharing the quote from a yellow bold button
- make the heart icon toggleable

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576e0f0d4483329174084def422203