### PR TITLE
Fix intl date locale init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Pildora_Biblica_app
 
 Repositorio del proyecto Píldora Bíblica
+
+## Uso de `intl` para fechas
+
+Este proyecto utiliza el paquete [`intl`](https://pub.dev/packages/intl) para
+formatear fechas en español. Antes de ejecutar la aplicación es necesario
+inicializar los datos de localización. Esto ya se realiza en `lib/main.dart`
+mediante la función `initializeDateFormatting('es_ES', null)`. Asegúrate de
+ejecutar `flutter pub get` para obtener las dependencias.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:intl/intl.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await initializeDateFormatting('es_ES', null);
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
## Summary
- initialize date formatting in main
- document intl localizations

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68577edaca148332ae354d98bc62d5bc