### PR TITLE
Change background color to yellow on CitaConfirmada screen

### DIFF
--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -13,7 +13,7 @@ class CitaConfirmada extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFFFAF6EF),
+      backgroundColor: Colors.yellow,
       body: SafeArea(
         child: TweenAnimationBuilder<double>(
           tween: Tween(begin: 0, end: 1),


### PR DESCRIPTION
## Summary
- change `CitaConfirmada` screen background color from off‑white to yellow

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bb0b995483328c0330f75704f719