### PR TITLE
Add modern devotional home UI

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+final Color _backgroundColor = const Color(0xFFFFF8E1);
+final Color _primaryColor = const Color(0xFFFF9800); // orange
+final Color _secondaryColor = const Color(0xFF7E57C2); // purple
+
+ThemeData buildAppTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    scaffoldBackgroundColor: _backgroundColor,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: _primaryColor,
+      background: _backgroundColor,
+    ),
+    textTheme: const TextTheme(
+      bodyMedium: TextStyle(fontSize: 16),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(24),
+        ),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        textStyle: const TextStyle(fontWeight: FontWeight.bold),
+      ),
+    ),
+  );
+}
+

--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -1,119 +1,173 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'custom_button.dart';
 
-class CitaConfirmada extends StatelessWidget {
-  final String cita;
-  final String fecha;
-
-  const CitaConfirmada({
-    super.key,
-    this.cita = 'LAMENTACIONES 3:25',
-    this.fecha = '21 JUN 2025',
-  });
+class CitaConfirmada extends StatefulWidget {
+  const CitaConfirmada({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.yellow,
-      body: SafeArea(
-        child: TweenAnimationBuilder<double>(
-          tween: Tween(begin: 0, end: 1),
-          duration: const Duration(milliseconds: 500),
-          builder: (context, value, child) {
-            return Opacity(
-              opacity: value,
-              child: Transform.translate(
-                offset: Offset(0, 40 * (1 - value)),
-                child: child,
-              ),
-            );
-          },
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                const Spacer(flex: 2),
-                CircleAvatar(
-                  radius: 48,
-                  backgroundColor: Colors.green.shade50,
-                  child: Icon(
-                    Icons.check,
-                    size: 56,
-                    color: Colors.green.shade700,
-                  ),
-                ),
-                const SizedBox(height: 24),
-                const Text(
-                  '¡Cita marcada como leída!',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.black87,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  fecha.toUpperCase(),
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: Colors.grey.shade700,
-                    letterSpacing: 1.2,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  cita,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
-                    letterSpacing: 1.2,
-                  ),
-                ),
-                const Spacer(flex: 2),
-                const _BotonAccion(texto: 'Leer Devocional'),
-                const SizedBox(height: 16),
-                const _BotonAccion(texto: 'Canción del día'),
-                const SizedBox(height: 16),
-                const _BotonAccion(texto: 'Diario de oración'),
-                const Spacer(flex: 3),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+  State<CitaConfirmada> createState() => _CitaConfirmadaState();
 }
 
-class _BotonAccion extends StatelessWidget {
-  final String texto;
-
-  const _BotonAccion({required this.texto});
+class _CitaConfirmadaState extends State<CitaConfirmada> {
+  int _selectedIndex = 0;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: double.infinity,
-      child: ElevatedButton(
-        onPressed: () {},
-        style: ElevatedButton.styleFrom(
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          backgroundColor: Colors.black,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(24),
+    final fecha = DateFormat('dd MMM yyyy', 'es_ES').format(DateTime.now()).toUpperCase();
+    final hora = DateFormat('HH:mm').format(DateTime.now());
+
+    Widget quickAction(IconData icon, String label, String duration) {
+      return Expanded(
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.grey.shade200,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Column(
+            children: [
+              Icon(icon, color: Colors.black87),
+              const SizedBox(height: 8),
+              Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 4),
+              Text(duration, style: TextStyle(color: Colors.grey.shade600)),
+            ],
           ),
         ),
-        child: Text(
-          texto,
-          style: const TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.bold,
-          ),
+      );
+    }
+
+    Widget essentialsAction(IconData icon, String label, String duration) {
+      return Container(
+        margin: const EdgeInsets.symmetric(vertical: 8),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
         ),
+        child: Row(
+          children: [
+            Icon(icon, color: Colors.black54),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
+                  Text(duration, style: TextStyle(color: Colors.grey.shade600)),
+                ],
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.purple.shade200,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: const Text('PLUS', style: TextStyle(color: Colors.white)),
+            )
+          ],
+        ),
+      );
+    }
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
+              child: Row(
+                children: [
+                  Text(hora, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  const Spacer(),
+                  const Text('Acércate a Dios', style: TextStyle(fontWeight: FontWeight.bold)),
+                  const Spacer(),
+                  const CircleAvatar(radius: 18, child: Icon(Icons.person)),
+                  IconButton(
+                    onPressed: () {},
+                    icon: const Icon(Icons.group),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(fecha, style: TextStyle(color: Colors.grey.shade600)),
+                          const SizedBox(height: 8),
+                          const Text(
+                            'Moisés, el que venció sus temores',
+                            style: TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
+                          ),
+                          const SizedBox(height: 8),
+                          Row(
+                            children: [
+                              Icon(Icons.local_offer, color: Colors.orange.shade300, size: 20),
+                              const SizedBox(width: 4),
+                              const Text('Cita Diaria'),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          const Text('LA CITA DE HOY ES DE:', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                          const SizedBox(height: 4),
+                          const Text(
+                            'Lamentaciones 3:25',
+                            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 22),
+                          ),
+                          const SizedBox(height: 12),
+                          AppButton(text: 'LEER', onPressed: () {}),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        quickAction(Icons.menu_book, 'Pasaje', '1 min'),
+                        quickAction(Icons.chat_bubble_outline, 'Devocional', '5 min'),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                    const Text(
+                      'ESENCIALES DE LA FE',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    essentialsAction(Icons.music_note, 'Canción del día', '5 min'),
+                    essentialsAction(Icons.emoji_emotions, 'Declaraciones', '3 min'),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: (i) => setState(() => _selectedIndex = i),
+        selectedItemColor: Colors.orange,
+        unselectedItemColor: Colors.grey,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.check_circle), label: 'Hoy'),
+          BottomNavigationBarItem(icon: Icon(Icons.headphones), label: 'Explora'),
+          BottomNavigationBarItem(icon: Icon(Icons.book), label: 'Biblia'),
+          BottomNavigationBarItem(icon: Icon(Icons.handshake), label: 'Oraciones'),
+          BottomNavigationBarItem(icon: Icon(Icons.edit), label: 'Diario'),
+        ],
       ),
     );
   }

--- a/lib/custom_button.dart
+++ b/lib/custom_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class AppButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+
+  const AppButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton.icon(
+        onPressed: onPressed,
+        icon: icon != null ? Icon(icon, size: 20) : const SizedBox.shrink(),
+        label: Text(text),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'app_theme.dart';
+import 'cita_confirmada.dart';
+import 'custom_button.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,6 +19,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Píldora Bíblica',
       debugShowCheckedModeBanner: false,
+      theme: buildAppTheme(),
       home: const PantallaBienvenida(),
     );
   }
@@ -38,31 +42,6 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
     );
   }
 
-  Widget _buildActionButton(String text, {Color textColor = Colors.yellow}) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 32.0),
-      child: SizedBox(
-        width: double.infinity,
-        child: ElevatedButton(
-          onPressed: () {},
-          style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.black,
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(30),
-            ),
-          ),
-          child: Text(
-            text,
-            style: TextStyle(
-              color: textColor,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 
   Widget _buildBienvenidaView() {
     return Column(
@@ -120,25 +99,10 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
         // Botón "Comparte la cita"
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 32.0),
-          child: SizedBox(
-            width: double.infinity,
-            child: ElevatedButton(
-              onPressed: _shareQuote,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.black,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-              ),
-              child: const Text(
-                'COMPARTE LA CITA',
-                style: TextStyle(
-                  color: Colors.yellow,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
+          child: AppButton(
+            text: 'COMPARTE LA CITA',
+            onPressed: _shareQuote,
+            icon: Icons.share,
           ),
         ),
 
@@ -162,62 +126,6 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
     );
   }
 
-  Widget _buildDevocionalView() {
-    final fecha = DateFormat('dd MMM yyyy', 'es_ES').format(DateTime.now()).toUpperCase();
-    return Container(
-      key: const ValueKey('devocional'),
-      color: Colors.yellow,
-      width: double.infinity,
-      child: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          children: [
-            const Spacer(flex: 2),
-            CircleAvatar(
-              radius: 40,
-              backgroundColor: Colors.green.shade100,
-              child: Icon(Icons.check, size: 50, color: Colors.green.shade700),
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              '¡Cita marcada como leída!',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-                color: Colors.black87,
-              ),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              fecha,
-              style: TextStyle(
-                fontSize: 14,
-                color: Colors.grey.shade700,
-                letterSpacing: 1.1,
-              ),
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              'LAMENTACIONES 3:25',
-              style: TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.bold,
-                color: Colors.black,
-                letterSpacing: 1.2,
-              ),
-            ),
-            const Spacer(flex: 2),
-            _buildActionButton('Leer Devocional', textColor: Colors.white),
-            const SizedBox(height: 16),
-            _buildActionButton('Canción del día', textColor: Colors.white),
-            const SizedBox(height: 16),
-            _buildActionButton('Diario de oración', textColor: Colors.white),
-            const Spacer(flex: 3),
-          ],
-        ),
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -239,7 +147,7 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
                 );
               },
               child: _mostrarDevocional
-                  ? _buildDevocionalView()
+                  ? const CitaConfirmada()
                   : _buildBienvenidaView(),
             ),
           ),


### PR DESCRIPTION
## Summary
- add `buildAppTheme` to centralize colors and fonts
- create reusable `AppButton` widget
- redesign confirmation screen with daily devotional layout, quick actions and bottom navigation
- display new confirmation interface using `AnimatedSwitcher`

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585ccd3e9c8332a89ef026ed560def