### PR TITLE
Implement welcome and devotional screens

### DIFF
--- a/lib/devocional_screen.dart
+++ b/lib/devocional_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class DevocionalScreen extends StatefulWidget {
+  final String cita;
+  final String versiculo;
+
+  const DevocionalScreen({
+    Key? key,
+    required this.cita,
+    required this.versiculo,
+  }) : super(key: key);
+
+  @override
+  State<DevocionalScreen> createState() => _DevocionalScreenState();
+}
+
+class _DevocionalScreenState extends State<DevocionalScreen> {
+  bool _leido = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Devocional diario')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.cita,
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+            ),
+            const SizedBox(height: 4),
+            Text(widget.versiculo),
+            const SizedBox(height: 8),
+            ExpansionTile(
+              title: const Text('Devocional'),
+              children: [
+                const Text(
+                  'Fortaleza en Cristo',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'A veces sentimos que nuestras fuerzas no son suficientes para los desafíos del día. Las preocupaciones, los problemas o nuestras propias limitaciones nos hacen dudar.',
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Pero este versículo nos recuerda que nuestra verdadera fortaleza viene de Cristo. No se trata solo de aguantar, sino de avanzar con fe sabiendo que Él nos da poder más allá de nuestras capacidades. Hoy, respira profundo, y dile a Dios: "Contigo, puedo hacerlo".',
+                ),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: _leido
+                        ? null
+                        : () {
+                            setState(() {
+                              _leido = true;
+                            });
+                          },
+                    child: _leido
+                        ? const Icon(Icons.check, color: Colors.green)
+                        : const Text('Marcar como leído'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,9 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
-import 'package:share_plus/share_plus.dart';
-import 'package:intl/intl.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'app_theme.dart';
-import 'cita_confirmada.dart';
-import 'custom_button.dart';
+import 'devocional_screen.dart';
 
-Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await initializeDateFormatting('es_ES', null);
+void main() {
   runApp(const MyApp());
 }
 
@@ -33,99 +28,52 @@ class PantallaBienvenida extends StatefulWidget {
 }
 
 class _PantallaBienvenidaState extends State<PantallaBienvenida> {
-  bool _isFavorite = false;
-  bool _mostrarDevocional = false;
+  late Map<String, String> _versiculo;
+  late String _fondo;
 
-  void _shareQuote() {
-    Share.share(
-      '"Bueno es el Señor con quienes esperan en él, con todos los que lo buscan."\nLAMENTACIONES 3:25',
-    );
+  final _versiculos = [
+    {
+      'cita': 'Jeremías 29:11',
+      'texto':
+          'Porque yo sé los planes que tengo para ustedes \u2014afirma el Señor\u2014, planes de bienestar y no de calamidad, a fin de darles un futuro y una esperanza.'
+    },
+    {
+      'cita': 'Salmos 23:1',
+      'texto': 'El Señor es mi pastor, nada me faltará.'
+    },
+    {
+      'cita': 'Filipenses 4:13',
+      'texto': 'Todo lo puedo en Cristo que me fortalece.'
+    }
+  ];
+
+  final _fondos = [
+    'assets/fondo1_pb_t1.jpg',
+    'assets/fondo2_pb_t1.jpg',
+    'assets/fondo3_pb_t1.jpg',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    final rnd = Random();
+    _versiculo = _versiculos[rnd.nextInt(_versiculos.length)];
+    _fondo = _fondos[rnd.nextInt(_fondos.length)];
   }
 
-
-  Widget _buildBienvenidaView() {
-    return Column(
-      key: const ValueKey('bienvenida'),
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        const Spacer(flex: 2),
-
-        // Logo
-        Image.asset('assets/logo_pildora.png', width: 100),
-        const SizedBox(height: 16),
-
-        // Texto de la cita
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 32.0),
-          child: Text(
-            'Bueno es el Señor con quienes esperan en él, con todos los que lo buscan.',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 20,
-              height: 1.5,
-            ),
-          ),
-        ),
-        const SizedBox(height: 16),
-
-        // Cita
-        const Text(
-          'LAMENTACIONES 3:25',
-          style: TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-
-        const SizedBox(height: 16),
-
-        // Icono de corazón
-        IconButton(
-          icon: Icon(
-            _isFavorite ? Icons.favorite : Icons.favorite_border,
-            color: _isFavorite ? Colors.red : Colors.white,
-          ),
-          iconSize: 30,
-          onPressed: () {
-            setState(() {
-              _isFavorite = !_isFavorite;
-            });
-          },
-        ),
-
-        const Spacer(),
-
-        // Botón "Comparte la cita"
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 32.0),
-          child: AppButton(
-            text: 'COMPARTE LA CITA',
-            onPressed: _shareQuote,
-            icon: Icons.share,
-          ),
-        ),
-
-        const SizedBox(height: 12),
-
-        // Texto "Toca aquí para concluir"
-        TextButton(
-          onPressed: () {
-            setState(() {
-              _mostrarDevocional = true;
-            });
-          },
-          child: const Text(
-            'TOCA AQUÍ PARA CONCLUIR',
-            style: TextStyle(color: Colors.white),
-          ),
-        ),
-
-        const SizedBox(height: 24),
-      ],
+  Route _crearRutaDevocional() {
+    return PageRouteBuilder(
+      pageBuilder: (_, __, ___) => DevocionalScreen(
+        cita: _versiculo['cita']!,
+        versiculo: _versiculo['texto']!,
+      ),
+      transitionsBuilder: (_, animation, __, child) {
+        final offset = Tween(begin: const Offset(0, -1), end: Offset.zero)
+            .animate(animation);
+        return SlideTransition(position: offset, child: child);
+      },
     );
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -133,22 +81,45 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
       body: Stack(
         fit: StackFit.expand,
         children: [
-          Image.asset('assets/fondo_amanecer.png', fit: BoxFit.cover),
+          Image.asset(_fondo, fit: BoxFit.cover),
           SafeArea(
-            child: AnimatedSwitcher(
-              duration: const Duration(milliseconds: 500),
-              transitionBuilder: (child, animation) {
-                return SlideTransition(
-                  position: Tween<Offset>(
-                    begin: const Offset(0, 1),
-                    end: Offset.zero,
-                  ).animate(animation),
-                  child: child,
-                );
-              },
-              child: _mostrarDevocional
-                  ? const CitaConfirmada()
-                  : _buildBienvenidaView(),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Spacer(flex: 2),
+                Image.asset('assets/logo_pildora.png', width: 100),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                  child: Text(
+                    _versiculo['texto']!,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 20,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  _versiculo['cita']!,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                  child: ElevatedButton(
+                    onPressed: () =>
+                        Navigator.of(context).push(_crearRutaDevocional()),
+                    child: const Text('TOCA AQUÍ PARA CONCLUIR'),
+                  ),
+                ),
+                const SizedBox(height: 24),
+              ],
             ),
           ),
         ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,9 @@ flutter:
   assets:
     - assets/fondo_amanecer.png
     - assets/logo_pildora.png
+    - assets/fondo1_pb_t1.jpg
+    - assets/fondo2_pb_t1.jpg
+    - assets/fondo3_pb_t1.jpg
     
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- show random background and verse on welcome page
- button transitions vertically to new devotional screen
- devotional screen includes an expandable section with mark-as-read
- add assets for background images

## Testing
- `flutter format lib/main.dart lib/devocional_screen.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685905e4b1d88332bffa52e871a2133a