### PR TITLE
Random verse backgrounds and devotional accordion

### DIFF
--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -15,7 +15,6 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
   @override
   Widget build(BuildContext context) {
     final fecha = DateFormat('dd MMM yyyy', 'es_ES').format(DateTime.now()).toUpperCase();
-    final hora = DateFormat('HH:mm').format(DateTime.now());
 
     Widget quickAction(IconData icon, String label, String duration) {
       return Expanded(
@@ -81,11 +80,10 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
               padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8),
               child: Row(
                 children: [
-                  Text(hora, style: const TextStyle(fontWeight: FontWeight.bold)),
-                  const Spacer(),
+                  const CircleAvatar(radius: 18, child: Icon(Icons.person)),
+                  const SizedBox(width: 12),
                   const Text('Acércate a Dios', style: TextStyle(fontWeight: FontWeight.bold)),
                   const Spacer(),
-                  const CircleAvatar(radius: 18, child: Icon(Icons.person)),
                   IconButton(
                     onPressed: () {},
                     icon: const Icon(Icons.group),
@@ -111,7 +109,7 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
                           Text(fecha, style: TextStyle(color: Colors.grey.shade600)),
                           const SizedBox(height: 8),
                           const Text(
-                            'Moisés, el que venció sus temores',
+                            'Devocional de ejemplo (Filipenses 4:13)',
                             style: TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
                           ),
                           const SizedBox(height: 8),
@@ -126,11 +124,24 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
                           const Text('LA CITA DE HOY ES DE:', style: TextStyle(color: Colors.grey, fontSize: 12)),
                           const SizedBox(height: 4),
                           const Text(
-                            'Lamentaciones 3:25',
+                            'Filipenses 4:13',
                             style: TextStyle(fontWeight: FontWeight.bold, fontSize: 22),
                           ),
                           const SizedBox(height: 12),
                           AppButton(text: 'LEER', onPressed: () {}),
+                          const SizedBox(height: 12),
+                          ExpansionTile(
+                            tilePadding: EdgeInsets.zero,
+                            title: Text('Devocional: Fortaleza en Cristo', style: TextStyle(color: Colors.black)),
+                            children: [
+                              Padding(
+                                padding: EdgeInsets.all(8.0),
+                                child: Text(
+                                  'A veces sentimos que nuestras fuerzas no son suficientes para los desafíos del día. Las preocupaciones, los problemas o nuestras propias limitaciones nos hacen dudar.\n\nPero este versículo nos recuerda que nuestra verdadera fortaleza viene de Cristo. No se trata solo de aguantar, sino de avanzar con fe sabiendo que Él nos da poder más allá de nuestras capacidades. Hoy, respira profundo, y dile a Dios: "Contigo, puedo hacerlo".',
+                                ),
+                              ),
+                            ],
+                          ),
                         ],
                       ),
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:math';
 import 'package:share_plus/share_plus.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -35,11 +36,39 @@ class PantallaBienvenida extends StatefulWidget {
 class _PantallaBienvenidaState extends State<PantallaBienvenida> {
   bool _isFavorite = false;
   bool _mostrarDevocional = false;
+  late final String _background;
+  late final Map<String, String> _versiculo;
+
+  @override
+  void initState() {
+    super.initState();
+    final random = Random();
+    final fondos = [
+      'assets/fondo1_pb_t1.jpg',
+      'assets/fondo2_pb_t1.jpg',
+      'assets/fondo3_pb_t1.jpg',
+    ];
+    final versiculos = [
+      {
+        'texto':
+            'Porque yo sé los planes que tengo para ustedes —afirma el Señor—, planes de bienestar y no de calamidad, a fin de darles un futuro y una esperanza.',
+        'cita': 'JEREMÍAS 29:11',
+      },
+      {
+        'texto': 'El Señor es mi pastor, nada me faltará.',
+        'cita': 'SALMOS 23:1',
+      },
+      {
+        'texto': 'Todo lo puedo en Cristo que me fortalece.',
+        'cita': 'FILIPENSES 4:13',
+      },
+    ];
+    _background = fondos[random.nextInt(fondos.length)];
+    _versiculo = versiculos[random.nextInt(versiculos.length)];
+  }
 
   void _shareQuote() {
-    Share.share(
-      '"Bueno es el Señor con quienes esperan en él, con todos los que lo buscan."\nLAMENTACIONES 3:25',
-    );
+    Share.share('"${_versiculo['texto']}"\n${_versiculo['cita']}');
   }
 
 
@@ -55,12 +84,12 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
         const SizedBox(height: 16),
 
         // Texto de la cita
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 32.0),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32.0),
           child: Text(
-            'Bueno es el Señor con quienes esperan en él, con todos los que lo buscan.',
+            _versiculo['texto']!,
             textAlign: TextAlign.center,
-            style: TextStyle(
+            style: const TextStyle(
               color: Colors.white,
               fontSize: 20,
               height: 1.5,
@@ -70,9 +99,9 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
         const SizedBox(height: 16),
 
         // Cita
-        const Text(
-          'LAMENTACIONES 3:25',
-          style: TextStyle(
+        Text(
+          _versiculo['cita']!,
+          style: const TextStyle(
             color: Colors.white,
             fontWeight: FontWeight.bold,
           ),
@@ -133,7 +162,7 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
       body: Stack(
         fit: StackFit.expand,
         children: [
-          Image.asset('assets/fondo_amanecer.png', fit: BoxFit.cover),
+          Image.asset(_background, fit: BoxFit.cover),
           SafeArea(
             child: AnimatedSwitcher(
               duration: const Duration(milliseconds: 500),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,9 @@ flutter:
   uses-material-design: true
   assets:
     - assets/fondo_amanecer.png
+    - assets/fondo1_pb_t1.jpg
+    - assets/fondo2_pb_t1.jpg
+    - assets/fondo3_pb_t1.jpg
     - assets/logo_pildora.png
     
   # To add assets to your application, add an assets section, like this:


### PR DESCRIPTION
## Summary
- add new background assets
- show a random verse and background on launch
- remove clock and move user avatar left on devotional screen
- add an accordion with a sample devotional text

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591291dccc8332a3098691e75dff30