### PR TITLE
Add points history screen

### DIFF
--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'custom_button.dart';
+import 'historial_puntos.dart';
 
 class CitaConfirmada extends StatefulWidget {
   const CitaConfirmada({super.key});
@@ -102,22 +103,32 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
                   const Spacer(),
-                  FutureBuilder<int>(
-                    future: _getPoints(),
-                    builder: (context, snapshot) {
-                      final puntos = snapshot.data ?? 0;
-                      return Row(
-                        children: [
-                          const Icon(Icons.star, color: Colors.orange),
-                          const SizedBox(width: 4),
-                          Text(
-                            '$puntos',
-                            style: const TextStyle(fontWeight: FontWeight.bold),
-                          ),
-                          const SizedBox(width: 16),
-                        ],
+                  GestureDetector(
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const HistorialPuntosScreen(),
+                        ),
                       );
                     },
+                    child: FutureBuilder<int>(
+                      future: _getPoints(),
+                      builder: (context, snapshot) {
+                        final puntos = snapshot.data ?? 0;
+                        return Row(
+                          children: [
+                            const Icon(Icons.star, color: Colors.orange),
+                            const SizedBox(width: 4),
+                            Text(
+                              '$puntos',
+                              style:
+                                  const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(width: 16),
+                          ],
+                        );
+                      },
+                    ),
                   ),
                   IconButton(onPressed: () {}, icon: const Icon(Icons.group)),
                 ],

--- a/lib/historial_puntos.dart
+++ b/lib/historial_puntos.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class EventoPuntos {
+  final String descripcion;
+  final int puntos;
+  final DateTime fecha;
+
+  EventoPuntos({required this.descripcion, required this.puntos, required this.fecha});
+}
+
+class HistorialPuntosScreen extends StatelessWidget {
+  const HistorialPuntosScreen({super.key});
+
+  final List<EventoPuntos> _eventos = const [
+    EventoPuntos(
+      descripcion: 'Entrada diaria',
+      puntos: 10,
+      fecha: DateTime(2025, 6, 23),
+    ),
+    EventoPuntos(
+      descripcion: 'Compartió la app',
+      puntos: 20,
+      fecha: DateTime(2025, 6, 22),
+    ),
+    EventoPuntos(
+      descripcion: 'Leyó el devocional',
+      puntos: 15,
+      fecha: DateTime(2025, 6, 21),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Historial de Puntos')),
+      body: ListView.builder(
+        itemCount: _eventos.length,
+        itemBuilder: (context, index) {
+          final evento = _eventos[index];
+          final fecha = DateFormat('dd MMM yyyy', 'es_ES')
+              .format(evento.fecha)
+              .toUpperCase();
+          return ListTile(
+            leading: const Icon(Icons.star, color: Colors.orange),
+            title: Text(evento.descripcion),
+            subtitle: Text(fecha),
+            trailing: Text(
+              '+${evento.puntos} puntos',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add screen to list point events
- link star icon to new screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2f2e7a548332a53052540b4b7e55