### PR TITLE
Fix const list error in historial_puntos.dart

### DIFF
--- a/lib/historial_puntos.dart
+++ b/lib/historial_puntos.dart
@@ -12,7 +12,7 @@ class EventoPuntos {
 class HistorialPuntosScreen extends StatelessWidget {
   const HistorialPuntosScreen({super.key});
 
-  final List<EventoPuntos> _eventos = const [
+  final List<EventoPuntos> _eventos = [
     EventoPuntos(
       descripcion: 'Entrada diaria',
       puntos: 10,


### PR DESCRIPTION
## Summary
- remove `const` from `_eventos` list to allow `DateTime` instances

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a351bb7988332823558674baba621