### PR TITLE
Fix constante en HistorialPuntosScreen

### DIFF
--- a/lib/historial_puntos.dart
+++ b/lib/historial_puntos.dart
@@ -14,7 +14,7 @@ class EventoPuntos {
 }
 
 class HistorialPuntosScreen extends StatelessWidget {
-  const HistorialPuntosScreen({super.key});
+  HistorialPuntosScreen({super.key});
 
   final List<EventoPuntos> _eventos = [
     EventoPuntos(


### PR DESCRIPTION
## Summary
- se quita el constructor `const` de `HistorialPuntosScreen` para evitar los errores de "Constant expression expected" al instanciar `DateTime`

## Testing
- `flutter test` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685a389b4a1083329c0b5a8055d5cfb1