### PR TITLE
Implement invite friend flow

### DIFF
--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'custom_button.dart';
 import 'historial_puntos.dart';
+import 'invitar_amigo_screen.dart';
 
 class CitaConfirmada extends StatefulWidget {
   const CitaConfirmada({super.key});
@@ -131,7 +132,16 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
                       },
                     ),
                   ),
-                  IconButton(onPressed: () {}, icon: const Icon(Icons.group)),
+                  IconButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => const InvitarAmigoScreen(),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.group),
+                  ),
                 ],
               ),
             ),

--- a/lib/historial_puntos.dart
+++ b/lib/historial_puntos.dart
@@ -13,35 +13,35 @@ class EventoPuntos {
   });
 }
 
+final List<EventoPuntos> eventosPuntosGlobal = [
+  EventoPuntos(
+    descripcion: 'Entrada diaria',
+    puntos: 10,
+    fecha: DateTime(2025, 6, 23),
+  ),
+  EventoPuntos(
+    descripcion: 'Compartió la app',
+    puntos: 20,
+    fecha: DateTime(2025, 6, 22),
+  ),
+  EventoPuntos(
+    descripcion: 'Leyó el devocional',
+    puntos: 15,
+    fecha: DateTime(2025, 6, 21),
+  ),
+];
+
 class HistorialPuntosScreen extends StatelessWidget {
   HistorialPuntosScreen({super.key});
-
-  final List<EventoPuntos> _eventos = [
-    EventoPuntos(
-      descripcion: 'Entrada diaria',
-      puntos: 10,
-      fecha: DateTime(2025, 6, 23),
-    ),
-    EventoPuntos(
-      descripcion: 'Compartió la app',
-      puntos: 20,
-      fecha: DateTime(2025, 6, 22),
-    ),
-    EventoPuntos(
-      descripcion: 'Leyó el devocional',
-      puntos: 15,
-      fecha: DateTime(2025, 6, 21),
-    ),
-  ];
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Historial de Puntos')),
       body: ListView.builder(
-        itemCount: _eventos.length,
+        itemCount: eventosPuntosGlobal.length,
         itemBuilder: (context, index) {
-          final evento = _eventos[index];
+          final evento = eventosPuntosGlobal[index];
           final fecha = DateFormat('dd MMM yyyy', 'es_ES')
               .format(evento.fecha)
               .toUpperCase();

--- a/lib/invitar_amigo_screen.dart
+++ b/lib/invitar_amigo_screen.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'custom_button.dart';
+import 'historial_puntos.dart';
+
+class InvitarAmigoScreen extends StatefulWidget {
+  const InvitarAmigoScreen({super.key});
+
+  @override
+  State<InvitarAmigoScreen> createState() => _InvitarAmigoScreenState();
+}
+
+class _InvitarAmigoScreenState extends State<InvitarAmigoScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nombreCtrl = TextEditingController();
+  final _telefonoCtrl = TextEditingController();
+  final _correoCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _nombreCtrl.dispose();
+    _telefonoCtrl.dispose();
+    _correoCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _sumarPuntos() async {
+    final prefs = await SharedPreferences.getInstance();
+    final total = prefs.getInt('totalPoints') ?? 0;
+    await prefs.setInt('totalPoints', total + 20);
+    eventosPuntosGlobal.insert(
+      0,
+      EventoPuntos(
+        descripcion: 'Compartió la app',
+        puntos: 20,
+        fecha: DateTime.now(),
+      ),
+    );
+  }
+
+  Future<void> _compartirWhatsApp(String mensaje) async {
+    final url = Uri.parse(
+        'https://wa.me/${_telefonoCtrl.text}?text=${Uri.encodeComponent(mensaje)}');
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+      await _sumarPuntos();
+    } else {
+      _mostrarError();
+    }
+  }
+
+  Future<void> _compartirSms(String mensaje) async {
+    final url = Uri.parse('sms:${_telefonoCtrl.text}?body=${Uri.encodeComponent(mensaje)}');
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url);
+      await _sumarPuntos();
+    } else {
+      _mostrarError();
+    }
+  }
+
+  Future<void> _compartirCorreo(String mensaje) async {
+    final correo = _correoCtrl.text;
+    final url = Uri.parse('mailto:$correo?subject=Invitaci%C3%B3n&body=${Uri.encodeComponent(mensaje)}');
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url);
+      await _sumarPuntos();
+    } else {
+      _mostrarError();
+    }
+  }
+
+  void _mostrarError() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('No se pudo compartir la invitación')),
+    );
+  }
+
+  void _mostrarOpciones(String mensaje) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.whatsapp, color: Colors.green),
+                title: const Text('WhatsApp'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _compartirWhatsApp(mensaje);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.sms, color: Colors.blue),
+                title: const Text('SMS'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _compartirSms(mensaje);
+                },
+              ),
+              if (_correoCtrl.text.isNotEmpty)
+                ListTile(
+                  leading: const Icon(Icons.email, color: Colors.orange),
+                  title: const Text('Correo electrónico'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    _compartirCorreo(mensaje);
+                  },
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _enviarInvitacion() {
+    if (!_formKey.currentState!.validate()) return;
+    final mensaje =
+        'Hola ${_nombreCtrl.text}, te invito a usar esta app devocional que me ha ayudado mucho a acercarme a Dios. ¡Descárgala aquí! https://ejemplo.com';
+    _mostrarOpciones(mensaje);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Invitar a un amigo')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nombreCtrl,
+                decoration: const InputDecoration(labelText: 'Nombre del amigo'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Campo obligatorio' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _telefonoCtrl,
+                decoration: const InputDecoration(labelText: 'Número de celular'),
+                keyboardType: TextInputType.phone,
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Campo obligatorio' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _correoCtrl,
+                decoration: const InputDecoration(labelText: 'Correo electrónico (opcional)'),
+                keyboardType: TextInputType.emailAddress,
+              ),
+              const SizedBox(height: 24),
+              AppButton(
+                text: 'Compartir invitación',
+                onPressed: _enviarInvitacion,
+                icon: Icons.share,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   share_plus: ^7.2.1
   intl: ^0.18.1
   shared_preferences: ^2.2.2
+  url_launcher: ^6.1.14
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add url_launcher dependency
- store global history list so other screens can add events
- create InvitarAmigoScreen to invite friends via WhatsApp, SMS or email
- link new screen from CitaConfirmada using group icon

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3fc18d088332b0e5f90003a6427c