### PR TITLE
Fix share points registration

### DIFF
--- a/lib/invitar_amigo_screen.dart
+++ b/lib/invitar_amigo_screen.dart
@@ -3,7 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'custom_button.dart';
-import 'historial_puntos.dart';
+import 'historial_puntos.dart' as puntos;
 
 class InvitarAmigoScreen extends StatefulWidget {
   const InvitarAmigoScreen({super.key});
@@ -30,9 +30,9 @@ class _InvitarAmigoScreenState extends State<InvitarAmigoScreen> {
     final prefs = await SharedPreferences.getInstance();
     final total = prefs.getInt('totalPoints') ?? 0;
     await prefs.setInt('totalPoints', total + 20);
-    eventosPuntosGlobal.insert(
+    puntos.eventosPuntosGlobal.insert(
       0,
-      EventoPuntos(
+      puntos.EventoPuntos(
         descripcion: 'Compartió la app',
         puntos: 20,
         fecha: DateTime.now(),


### PR DESCRIPTION
## Summary
- alias historial_puntos for global event access
- update invite screen to register share events using alias

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter run -d chrome` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1bd7b8f083329f78281d05a57877