### PR TITLE
Add registration screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'app_theme.dart';
 import 'cita_confirmada.dart';
 import 'custom_button.dart';
+import 'registro_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,7 +23,7 @@ class MyApp extends StatelessWidget {
       title: 'Píldora Bíblica',
       debugShowCheckedModeBanner: false,
       theme: buildAppTheme(),
-      home: const PantallaBienvenida(),
+      home: const RegistroScreen(),
     );
   }
 }

--- a/lib/registro_screen.dart
+++ b/lib/registro_screen.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import 'main.dart';
+
+class RegistroScreen extends StatefulWidget {
+  const RegistroScreen({super.key});
+
+  @override
+  State<RegistroScreen> createState() => _RegistroScreenState();
+}
+
+class _RegistroScreenState extends State<RegistroScreen> {
+  final _emailCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailCtrl.dispose();
+    _passwordCtrl.dispose();
+    super.dispose();
+  }
+
+  void _mostrarDetallesCuenta() {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Detalles de la cuenta'),
+        content: const Text('Aún no has creado una cuenta.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cerrar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _registrarse() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const PantallaBienvenida()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Píldora Bíblica'),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.help_outline),
+          onPressed: _mostrarDetallesCuenta,
+        ),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const SizedBox(height: 24),
+            const Text(
+              'Bienvenido a Píldora Bíblica',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              'Únete a nuestra comunidad de fe e inspiración. Regístrate o inicia sesión para acceder a los devocionales diarios.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _emailCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Correo electrónico',
+                filled: true,
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Contraseña',
+                filled: true,
+              ),
+              obscureText: true,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _registrarse,
+              child: const Text('Registrarse'),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'O regístrate con',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.grey,
+                      foregroundColor: Colors.black,
+                    ),
+                    child: const Text('Google'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.grey,
+                      foregroundColor: Colors.black,
+                    ),
+                    child: const Text('Facebook'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            TextButton(
+              onPressed: () {},
+              child: const Text('¿Ya tienes una cuenta? Inicia sesión'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add RegistroScreen with email/password fields, social sign-up buttons, and a help icon on the top-left
- use RegistroScreen as the home screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8283ecec83328f2eb849571c3a09