### PR TITLE
Fix PLUS background color

### DIFF
--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -76,7 +76,7 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
-                color: Colors.purple.shade200,
+                color: Colors.green.shade200,
                 borderRadius: BorderRadius.circular(12),
               ),
               child: const Text('PLUS', style: TextStyle(color: Colors.white)),


### PR DESCRIPTION
## Summary
- change background color of PLUS label from purple to green in `cita_confirmada.dart`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c7269b1008332b3d0b527ff3c4580