### PR TITLE
Update transition animation and highlight color

### DIFF
--- a/lib/cita_confirmada.dart
+++ b/lib/cita_confirmada.dart
@@ -76,7 +76,7 @@ class _CitaConfirmadaState extends State<CitaConfirmada> {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
-                color: Colors.green.shade200,
+                color: Colors.red.shade200,
                 borderRadius: BorderRadius.circular(12),
               ),
               child: const Text('PLUS', style: TextStyle(color: Colors.white)),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -189,11 +189,15 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida> {
               duration: const Duration(milliseconds: 500),
               transitionBuilder: (child, animation) {
                 if (child.key == const ValueKey('bienvenida') && _mostrarDevocional) {
+                  final curved = CurvedAnimation(
+                    parent: animation,
+                    curve: Curves.easeInOut,
+                  );
                   return SlideTransition(
                     position: Tween<Offset>(
                       begin: Offset.zero,
                       end: const Offset(0, 1),
-                    ).animate(animation),
+                    ).animate(curved),
                     child: child,
                   );
                 }


### PR DESCRIPTION
## Summary
- smooth slide down transition when moving from daily verse view to main screen
- change highlight tag `PLUS` to use red background

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c780954c48332a32fa6ef886efe7d