### PR TITLE
Fix overlay and rename main screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'app_theme.dart';
-import 'cita_confirmada.dart';
+import 'pantalla_principal.dart';
 import 'custom_button.dart';
 import 'registro_screen.dart';
 
@@ -204,12 +204,15 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida>
         fit: StackFit.expand,
         children: [
           Image.asset(_background, fit: BoxFit.cover),
-          const SafeArea(child: CitaConfirmada()),
+          const SafeArea(child: PantallaPrincipal()),
           if (!_overlayDismissed)
-            SafeArea(
-              child: SlideTransition(
-                position: _slideAnimation,
-                child: _buildBienvenidaView(),
+            SlideTransition(
+              position: _slideAnimation,
+              child: Container(
+                color: Colors.black54,
+                width: double.infinity,
+                height: double.infinity,
+                child: SafeArea(child: _buildBienvenidaView()),
               ),
             ),
         ],

--- a/lib/pantalla_principal.dart
+++ b/lib/pantalla_principal.dart
@@ -5,14 +5,14 @@ import 'custom_button.dart';
 import 'historial_puntos.dart';
 import 'invitar_amigo_screen.dart';
 
-class CitaConfirmada extends StatefulWidget {
-  const CitaConfirmada({super.key});
+class PantallaPrincipal extends StatefulWidget {
+  const PantallaPrincipal({super.key});
 
   @override
-  State<CitaConfirmada> createState() => _CitaConfirmadaState();
+  State<PantallaPrincipal> createState() => _PantallaPrincipalState();
 }
 
-class _CitaConfirmadaState extends State<CitaConfirmada> {
+class _PantallaPrincipalState extends State<PantallaPrincipal> {
   int _selectedIndex = 0;
 
   Future<int> _getPoints() async {


### PR DESCRIPTION
## Summary
- rename `CitaConfirmada` to `PantallaPrincipal`
- update references to the renamed screen
- add dark background to the welcome overlay so the main screen is not visible underneath

## Testing
- `dart format lib` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9f90b5d4833285e7da5112b221fe