### PR TITLE
Fix overlay flicker on registration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,6 +80,8 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida>
       begin: Offset.zero,
       end: const Offset(0, 1),
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+    precacheImage(AssetImage(_background), context);
+    precacheImage(AssetImage(_overlayBackground), context);
     _checkDailyPoints();
   }
 
@@ -206,7 +208,8 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida>
         fit: StackFit.expand,
         children: [
           Image.asset(_background, fit: BoxFit.cover),
-          const SafeArea(child: PantallaPrincipal()),
+          if (_overlayDismissed)
+            const SafeArea(child: PantallaPrincipal()),
           if (!_overlayDismissed)
             SlideTransition(
               position: _slideAnimation,
@@ -214,6 +217,7 @@ class _PantallaBienvenidaState extends State<PantallaBienvenida>
                 width: double.infinity,
                 height: double.infinity,
                 decoration: BoxDecoration(
+                  color: Colors.black,
                   image: DecorationImage(
                     image: AssetImage(_overlayBackground),
                     fit: BoxFit.cover,


### PR DESCRIPTION
## Summary
- preload welcome images to avoid flicker
- hide main screen until welcome overlay is dismissed
- show black background while the overlay image loads

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cabfb52d083329e018b0f2a205c82