### PR TITLE
Add login screen

### DIFF
--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import 'main.dart';
+import 'registro_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailCtrl = TextEditingController();
+  final _passwordCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailCtrl.dispose();
+    _passwordCtrl.dispose();
+    super.dispose();
+  }
+
+  void _iniciarSesion() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => const PantallaBienvenida()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Píldora Bíblica'),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const SizedBox(height: 24),
+            const Text(
+              'Inicia sesión',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _emailCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Correo electrónico',
+                filled: true,
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Contraseña',
+                filled: true,
+              ),
+              obscureText: true,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _iniciarSesion,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF4798ea),
+              ),
+              child: const Text('Iniciar sesión'),
+            ),
+            const SizedBox(height: 24),
+            TextButton(
+              onPressed: () {
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const RegistroScreen()),
+                );
+              },
+              child: const Text('¿No tienes una cuenta? Regístrate'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/registro_screen.dart
+++ b/lib/registro_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'main.dart';
+import 'login_screen.dart';
 
 class RegistroScreen extends StatefulWidget {
   const RegistroScreen({super.key});
@@ -168,7 +169,12 @@ class _RegistroScreenState extends State<RegistroScreen> {
             ),
             const SizedBox(height: 24),
             TextButton(
-              onPressed: () {},
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const LoginScreen()),
+                );
+              },
               child: const Text('¿Ya tienes una cuenta? Inicia sesión'),
             ),
           ],


### PR DESCRIPTION
## Summary
- add new login screen with email and password fields
- link the sign up screen to the new login page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f7c85a51c8332b737720f36ade944